### PR TITLE
review free strategy (only other type than rgb / xyz are free).

### DIFF
--- a/lymui/argb.c
+++ b/lymui/argb.c
@@ -45,8 +45,6 @@ Argb *getARgbFromXyz(Xyz *xyz) {
     argb->g = adobeGammaCorrection(g);
     argb->b = adobeGammaCorrection(b);
     argb->error = NULL;
-    
-    free(xyz);
-    
+        
     return argb;
 }

--- a/lymui/cymk.c
+++ b/lymui/cymk.c
@@ -78,5 +78,6 @@ Rgb *getRgbFromCymk(Cymk *cymk) {
     rgb->error = NULL;
     
     free(value);
+    free(cymk);
     return rgb;
 }

--- a/lymui/hsl.c
+++ b/lymui/hsl.c
@@ -41,7 +41,6 @@ Hsl *getHslFromRgb(Rgb *rgb) {
     hsl->s = sat * 100.0;
     hsl->l = _l * 100.0;
     hsl->error = NULL;
-    free(rgb);
     
     return hsl;
 }

--- a/lymui/hsv.c
+++ b/lymui/hsv.c
@@ -46,7 +46,6 @@ Hsv *getHsvFromRgb(Rgb *rgb) {
         hsv->s = 0.0;
     }
     
-    free(rgb);
     return hsv;
 }
 

--- a/lymui/lab.c
+++ b/lymui/lab.c
@@ -45,8 +45,6 @@ Lab *getLabFromXyz(Xyz *xyz) {
     lab->b = 200.0 * (calculateDomain(xyz->y / refY) - calculateDomain(xyz->z / refZ));
     lab->error = NULL;
     
-    free(xyz);
-    
     return lab;
 }
 
@@ -90,7 +88,6 @@ Lab *getHunterLabFromXyz(Xyz *xyz) {
     lab->b = 100.0 * kAkB[1] * ((xyz->y / Yn - xyz->z / Zn) / sqrtf(xyz->y / Yn));
     lab->error = NULL;
     
-    free(xyz);
     free(kAkB);
     
     return lab;

--- a/lymui/luv.c
+++ b/lymui/luv.c
@@ -73,7 +73,6 @@ Luv *getLuvFromXyz(Xyz *xyz) {
     luv->v = 13.0 * l * (uv[1] - urv[1]);
     luv->error = NULL;
     
-    free(xyz);
     free(urv);
     free(uv);
     

--- a/lymui/srgb.c
+++ b/lymui/srgb.c
@@ -59,8 +59,6 @@ SRgb *getSrgbFromXyz(Xyz *xyz) {
     srgb->b = gammaCorrection(b);
     srgb->error = NULL;
     
-    free(xyz);
-    
     return srgb;
 }
 

--- a/lymui/tests/argb_test.c
+++ b/lymui/tests/argb_test.c
@@ -31,6 +31,7 @@ ctest_return_t testARgbCreation(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, 0.37, argb->b, 0.01, "Expect b to be equal to be equal to 0.37 but got %f", argb->b);
     
     free(argb);
+    free(xyz);
 }
 
 ctest_return_t testARgbEmpty(ctest_t *test, void *arg) {
@@ -47,6 +48,8 @@ ctest_return_t testARgbEmpty(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, 0.0, argb->b, 0.1, "Expect b to be equal to be equal to 0 but got %f", argb->b);
     
     free(argb);
+    free(xyz);
+    free(rgb);
 }
 
 ctest_return_t testMaxARgb(ctest_t *test, void *arg) {
@@ -63,6 +66,8 @@ ctest_return_t testMaxARgb(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, 1.0, argb->b, 0.1, "Expect b to be equal to be equal to 0 but got %f", argb->b);
     
     free(argb);
+    free(xyz);
+    free(rgb);
 }
 
 ctest_return_t testNullARgb(ctest_t *test, void *arg) {

--- a/lymui/tests/cymk_test.c
+++ b/lymui/tests/cymk_test.c
@@ -26,17 +26,21 @@ ctest_return_t testCymkCreation(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, 0.0, cymk->k, 0.1, "Expect K to be equal to %f but got %f", 0.0, cymk->k);
     
     free(cymk);
+    free(rgb);
 }
 
 ctest_return_t testCymkBlackCreation(ctest_t *test, void *arg) {
     uint8_t uc[] = {0, 0, 0};
     Rgb *rgb = makeRGB(uc, 3);
-    Cymk * cymk = getCymkFromRgb(rgb);
+    Cymk *cymk = getCymkFromRgb(rgb);
     
     CTAssertDecimalEqual(test, 0.0, cymk->c, 0.1, "Expect C to be equal to %f but got %f", 0.0, cymk->c);
     CTAssertDecimalEqual(test, 0.0, cymk->y, 0.1, "Expect Y to be equal to %f but got %f", 0.0, cymk->y);
     CTAssertDecimalEqual(test, 0.0, cymk->m, 0.1, "Expect M to be equal to %f but got %f", 0.0, cymk->m);
     CTAssertDecimalEqual(test, 1.0, cymk->k, 0.1, "Expect K to be equal to %f but got %f", 0.0, cymk->k);
+    
+    free(rgb);
+    free(cymk);
 }
 
 ctest_return_t testCymkNullCreation(ctest_t *test, void *arg) {
@@ -60,7 +64,6 @@ ctest_return_t testCymkToRgbColor(ctest_t *test, void *arg) {
     CTAssertEqual(test, 10, rgb->g, "Expect G to be equal to %i but got %i", 10, rgb->g);
     CTAssertEqual(test, 198, rgb->b, "Expect B to be equal to %i but got %i", 198, rgb->b);
     
-    free(cymk);
     free(rgb);
 }
 
@@ -77,7 +80,6 @@ ctest_return_t testCymkToRgb(ctest_t *test, void *arg) {
     CTAssertEqual(test, 0, color->g, "Expect G to be equal to %i but got %i", 0, color->g);
     CTAssertEqual(test, 0, color->b, "Expect B to be equal to %i but got %i", 0, color->b);
 
-    free(cymk);
     free(color);
 }
 

--- a/lymui/tests/hsl_test.c
+++ b/lymui/tests/hsl_test.c
@@ -23,6 +23,7 @@ ctest_return_t testHslCreation(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, 19.6, hsl->l, 0.1, "Expect L to be equal to 19.6 but got %f", hsl->l);
 
     free(hsl);
+    free(rgb);
 }
 
 ctest_return_t testHighSaturationHsl(ctest_t *test, void *arg) {
@@ -35,6 +36,7 @@ ctest_return_t testHighSaturationHsl(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, 69.6, hsl->l, 0.1, "Expect L to be equal to 69.6 but got %f", hsl->l);
     
     free(hsl);
+    free(rgb);
 }
 
 ctest_return_t testLowSaturationHsl(ctest_t *test, void *arg) {
@@ -47,6 +49,7 @@ ctest_return_t testLowSaturationHsl(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, 2.0, hsl->l, 0.1, "Expect L to be equal to 2.0 but got %f", hsl->l);
     
     free(hsl);
+    free(rgb);
 }
 
 ctest_return_t testBlackHsl(ctest_t *test, void *arg) {
@@ -59,6 +62,7 @@ ctest_return_t testBlackHsl(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, 0.0, hsl->l, 0.1, "Expect L to be equal to 0 but got %f", hsl->l);
     
     free(hsl);
+    free(rgb);
 }
 
 ctest_return_t testWhiteHsl(ctest_t *test, void *arg) {
@@ -71,6 +75,7 @@ ctest_return_t testWhiteHsl(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, 100.0, hsl->l, 0.1, "Expect L to be equal to 100.0 but got %f", hsl->l);
     
     free(hsl);
+    free(rgb);
 }
 
 ctest_return_t testRgbGrayCreationFromHsv(ctest_t *test, void *arg) {

--- a/lymui/tests/hsv_test.c
+++ b/lymui/tests/hsv_test.c
@@ -33,6 +33,7 @@ ctest_return_t testHsvCreation(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, 39.2, hsv->v, 0.1, "Expect V to be equal to 39.2 but got %f", hsv->v);
     
     free(hsv);
+    free(rgb);
 }
 
 ctest_return_t testBlackHsvCreation(ctest_t *test, void *arg) {
@@ -47,6 +48,7 @@ ctest_return_t testBlackHsvCreation(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, 0.0, hsv->v, 0.1, "Expect V to be equal to 0 but got %f", hsv->v);
     
     free(hsv);
+    free(rgb);
 }
 
 ctest_return_t testComplexHsvCreation(ctest_t *test, void *arg) {
@@ -61,6 +63,7 @@ ctest_return_t testComplexHsvCreation(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, 93.3, hsv->v, 0.1, "Expect V to be equal to 93.3 but got %f", hsv->v);
     
     free(hsv);
+    free(rgb);
 }
 
 ctest_return_t testCaseRgb_0(ctest_t *test, void *arg) {
@@ -69,7 +72,7 @@ ctest_return_t testCaseRgb_0(ctest_t *test, void *arg) {
     hsv->s = 100.0;
     hsv->v = 100.0;
     
-     Rgb *rgb = getRgbFromHsv(hsv);
+    Rgb *rgb = getRgbFromHsv(hsv);
     CTAssertEqual(test, 255, rgb->r, "Expect r to be equal to 255 but got %ui", rgb->r);
     CTAssertEqual(test, 0, rgb->g, "Expect g to be equal to 0 but got %ui", rgb->g);
     CTAssertEqual(test, 0, rgb->b, "Expect b to be equal to 0 but got %ui", rgb->b);

--- a/lymui/tests/hwb_test.c
+++ b/lymui/tests/hwb_test.c
@@ -26,6 +26,7 @@ ctest_return_t testRgbToHwb(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, hwb->b, 63.52f, 0.01f, "Expect B to be equal to %f but got %f", 63.5f, hwb->b);
     
     free(hwb);
+    free(rgb);
 }
 
 ctest_return_t testWhiteRgbToHwb(ctest_t *test, void *arg) {
@@ -41,6 +42,7 @@ ctest_return_t testWhiteRgbToHwb(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, hwb->b, 0.0f, 0.01f, "Expect B to be equal to %f but got %f", 0.0f, hwb->b);
 
     free(hwb);
+    free(rgb);
 }
 
 ctest_return_t testBlackRgbToHwb(ctest_t *test, void *arg) {
@@ -56,6 +58,7 @@ ctest_return_t testBlackRgbToHwb(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, hwb->b, 100.0f, 0.01f, "Expect B to be equal to %f but got %f", 100.0f, hwb->b);
     
     free(hwb);
+    free(rgb);
 }
 
 ctest_return_t testHwbToRgb(ctest_t *test, void *arg) {

--- a/lymui/tests/lab_test.c
+++ b/lymui/tests/lab_test.c
@@ -30,6 +30,8 @@ ctest_return_t testLabFromXyz(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, -83.43, lab->b, 0.01, "Expect B to be equal to %f but got %f real value is %f", -83.43, lab->b);
 
     free(lab);
+    free(rgb);
+    free(xyz);
 }
 
 ctest_return_t testBlackLabFromXyz(ctest_t *test, void *arg) {
@@ -46,6 +48,8 @@ ctest_return_t testBlackLabFromXyz(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, 0.0, lab->b, 0.01, "Expect B to be equal to %f but got %f", 0.0, lab->b);
 
     free(lab);
+    free(rgb);
+    free(xyz);
 }
 
 ctest_return_t testWhiteLab(ctest_t *test, void *arg) {
@@ -62,6 +66,8 @@ ctest_return_t testWhiteLab(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, 0.0, lab->b, 0.001, "Expect B to be equal to %f but got %f", 0.0, lab->b);
 
     free(lab);
+    free(rgb);
+    free(xyz);
 }
 
 ctest_return_t testNullLab(ctest_t *test, void *arg) {
@@ -86,6 +92,8 @@ ctest_return_t testXyzFromLab(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, xyz->x, nXyz->x, 0.001,"Expect Z to be equal to %f but got %f", xyz->z, nXyz->z);
 
     free(nXyz);
+    free(rgb);
+    free(xyz);
 }
 
 ctest_return_t testXyzFromSmallLab(ctest_t *test, void *arg) {
@@ -117,6 +125,8 @@ ctest_return_t testXyzFromLargeLab(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, 1.0888, nXyz->z, 0.0001, "Expect Z to be equal to current xyz %f but got %f", 1.0888, nXyz->z);
 
     free(nXyz);
+    free(rgb);
+    free(xyz);
 }
 
 ctest_return_t testXyzNullCreation(ctest_t *test, void *arg) {
@@ -140,6 +150,8 @@ ctest_return_t testHunterLabFromXyz(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, 31.22, hunterLab->b, 0.01, "Expect B to be equal to %f but got %f", 31.22, hunterLab->b);
 
     free(hunterLab);
+    free(rgb);
+    free(xyz);
 }
 
 ctest_return_t testNullHunter(ctest_t *test, void *arg) {

--- a/lymui/tests/lch_lab_test.c
+++ b/lymui/tests/lch_lab_test.c
@@ -26,6 +26,7 @@ ctest_return_t testLchFromLab(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, lch->h, 307.23, 0.1, "Expect H to be equal to %f but got %f", 307.23, lch->h);
     
     free(lch);
+    free(xyz);
 }
 
 ctest_return_t testWhiteLchFromLab(ctest_t *test, void *arg) {
@@ -41,6 +42,7 @@ ctest_return_t testWhiteLchFromLab(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, lch->h, 19.24, 0.1, "Expect H to be equal to %f but got %f", 19.24, lch->h);
     
     free(lch);
+    free(xyz);
 }
 
 ctest_return_t testDarkLchFromLab(ctest_t *test, void *arg) {
@@ -56,6 +58,7 @@ ctest_return_t testDarkLchFromLab(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, lch->h, 0.0, 0.1, "Expect H to be equal to %f but got %f", 0.0, lch->h);
     
     free(lch);
+    free(xyz);
 }
 
 
@@ -78,6 +81,7 @@ ctest_return_t testXyzFromLchLab(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, 0.55, nXyz->z, 0.01, "Expect Z to be equal to %f but got %f", 0.56, nXyz->z);
 
     free(nXyz);
+    free(xyz);
 }
 
 ctest_return_t testLabLchNull(ctest_t *test, void *arg) {

--- a/lymui/tests/lch_test.c
+++ b/lymui/tests/lch_test.c
@@ -26,6 +26,7 @@ ctest_return_t testLchFromXyz(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, lch->h, 37.5, 0.01, "Expect H to be equal to %f but got %f", 37.5, lch->h);
     
     free(lch);
+    free(xyz);
 }
 
 ctest_return_t testLchFromMaxXyz(ctest_t *test, void *arg) {
@@ -41,6 +42,7 @@ ctest_return_t testLchFromMaxXyz(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, lch->h, 22.85, 0.01, "Expect H to be equal to %f but got %f", 22.85, lch->h);
 
     free(lch);
+    free(xyz);
 }
 
 ctest_return_t testLchFromFullWhiteXyz(ctest_t *test, void *arg) {
@@ -56,6 +58,7 @@ ctest_return_t testLchFromFullWhiteXyz(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, lch->h, 360.0, 0.1, "Expect H to be equal to %f but got %f", 360.0, lch->h);
     
     free(lch);
+    free(xyz);
 }
 
 ctest_return_t testLchFromMinXyz(ctest_t *test, void *arg) {
@@ -71,6 +74,7 @@ ctest_return_t testLchFromMinXyz(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, lch->h, 180.0, 0.1, "Expect H to be equal to 0 but got %f", lch->h);
 
     free(lch);
+    free(xyz);
 }
 
 ctest_return_t testNullLch(ctest_t *test, void *arg) {
@@ -93,6 +97,7 @@ ctest_return_t testLchToXyz(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, nXyz->z, 0.510, 0.001, "Expect Z to be equal to 0.501f but got %f", nXyz->z);
     
     free(nXyz);
+    free(xyz);
 }
 
 ctest_return_t testBrightLchToXyz(ctest_t *test, void *arg) {
@@ -109,6 +114,7 @@ ctest_return_t testBrightLchToXyz(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, nXyz->z, 1.088, 0.001, "Expect Z to be equal to 1.088 but got %f", nXyz->z);
     
     free(nXyz);
+    free(xyz);
 }
 
 ctest_return_t testDarkLchToXyz(ctest_t *test, void *arg) {
@@ -125,6 +131,7 @@ ctest_return_t testDarkLchToXyz(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, nXyz->z, 0, 0.001, "Expect Z to be equal to 0 but got %f", nXyz->z);
     
     free(nXyz);
+    free(xyz);
 }
 
 

--- a/lymui/tests/luv_test.c
+++ b/lymui/tests/luv_test.c
@@ -29,6 +29,8 @@ ctest_return_t testLuvFromXyz(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, -34.829, luv->v, 0.001, "Expect V to be equal to %f but got %f", -34.829, luv->v);
 
     free(luv);
+    free(rgb);
+    free(xyz);
 }
 
 ctest_return_t testSuperiorYLuvFromXyz(ctest_t *test, void *arg) {
@@ -45,6 +47,8 @@ ctest_return_t testSuperiorYLuvFromXyz(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, -5.983, luv->v, 0.001, "Expect V to be equal to %f but got %f", -5.983, luv->v);
     
     free(luv);
+    free(rgb);
+    free(xyz);
 }
 
 ctest_return_t testWhiteLuvFromXyz(ctest_t *test, void *arg) {
@@ -61,6 +65,8 @@ ctest_return_t testWhiteLuvFromXyz(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, 0.0, luv->v, 0.01, "Expect V to be equal to %f but got %f", 0.0, luv->v);
 
     free(luv);
+    free(rgb);
+    free(xyz);
 }
 
 ctest_return_t testInferiorYLuvFromXyz(ctest_t *test, void *arg) {
@@ -77,6 +83,8 @@ ctest_return_t testInferiorYLuvFromXyz(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, 0.442, luv->v, 0.001, "Expect V to be equal to %f but got %f", 0.442, luv->v);
 
     free(luv);
+    free(rgb);
+    free(xyz);
 }
 
 ctest_return_t testNullLuv(ctest_t *test, void *arg) {
@@ -118,6 +126,8 @@ ctest_return_t testHighXyzFromLuv(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, 1.0890, nXyz->z, 0.001, "Expect Z to be equal to %f but got %f", 1.0890, nXyz->z);
 
     free(nXyz);
+    free(rgb);
+    free(xyz);
 }
 
 ctest_return_t testNullXyz(ctest_t *test, void *arg) {

--- a/lymui/tests/srgb_test.c
+++ b/lymui/tests/srgb_test.c
@@ -30,6 +30,7 @@ ctest_return_t testSRgbCreation(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, 0.37, srgb->b, 0.01, "Expect b to be equal to be equal to 0.37 but got %f", srgb->b);
 
     free(srgb);
+    free(rgb);
 }
 
 ctest_return_t testXyzCreation(ctest_t *test, void *arg) {
@@ -63,6 +64,7 @@ ctest_return_t testWhiteXyzCreation(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, 1.0888, nXyz->z, 0.01, "Expect z to be equal to be equal to 1.0888 but got %f", nXyz->z);
     
     free(nXyz);
+    free(xyz);
 }
 
 ctest_return_t testNullSRgbCreation(ctest_t *test, void *arg) {

--- a/lymui/tests/tsl_test.c
+++ b/lymui/tests/tsl_test.c
@@ -26,6 +26,7 @@ ctest_return_t testWhiteRgbFromTsl(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, 255.0, tsl->l, 0.1, "Expect L to be equal to %f but got %f", 255.0, tsl->l);
     
     free(tsl);
+    free(rgb);
 }
 
 ctest_return_t testBlackRgbFromTsl(ctest_t *test, void *arg) {
@@ -41,6 +42,7 @@ ctest_return_t testBlackRgbFromTsl(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, 0.0, tsl->l, 0.1, "Expect L to be equal to %f but got %f", 0.0, tsl->l);
     
     free(tsl);
+    free(rgb);
 }
 
 ctest_return_t testTslFromRgb(ctest_t *test, void *arg) {
@@ -56,6 +58,7 @@ ctest_return_t testTslFromRgb(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, 35.412, tsl->l, 0.001, "Expect L to be equal to %f but got %f", 35.412, tsl->l);
     
     free(tsl);
+    free(rgb);
 }
 
 ctest_return_t testOtherTslFromRgb(ctest_t *test, void *arg) {
@@ -69,6 +72,9 @@ ctest_return_t testOtherTslFromRgb(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, 0.0764, tsl->t, 0.0001, "Expect T to be equal to %f but got %f", 0.0764, tsl->t);
     CTAssertDecimalEqual(test, 0.1361, tsl->s, 0.001, "Expect S to be equal to %f but got %f", 0.1361, tsl->s);
     CTAssertDecimalEqual(test, 178.244, tsl->l, 0.001, "Expect L to be equal to %f but got %f", 178.244, tsl->l);
+    
+    free(tsl);
+    free(rgb);
 }
 
 ctest_return_t testNullRgbParam(ctest_t *test, void *arg) {

--- a/lymui/tests/xyy_test.c
+++ b/lymui/tests/xyy_test.c
@@ -27,6 +27,7 @@ ctest_return_t testXyyFromXyz(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, 0.8, xyy->Y, 0.01, "Expect Y to be equal to 0.8 but got %f", xyy->Y);
 
     free(xyy);
+    free(xyz);
 }
 
 ctest_return_t testXyyFromZeroXyz(ctest_t *test, void *arg) {
@@ -42,6 +43,7 @@ ctest_return_t testXyyFromZeroXyz(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, 0.0, xyy->Y, 0.01, "Expect Y to be equal to 0.0f but got %f", xyy->Y);
     
     free(xyy);
+    free(xyz);
 }
 
 ctest_return_t testXyzFromXyy(ctest_t *test, void *arg) {

--- a/lymui/tests/xyz_test.c
+++ b/lymui/tests/xyz_test.c
@@ -28,6 +28,7 @@ ctest_return_t testXyzRgb(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, 0.1097, xyz->z, 0.01, "Expect Z to be equal to %f but got %f", 0.1097, xyz->z);
     
     free(xyz);
+    free(rgb);
 }
 
 ctest_return_t testXyzAdobeRgb(ctest_t *test, void *arg) {
@@ -43,6 +44,7 @@ ctest_return_t testXyzAdobeRgb(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, 0.1138, xyz->z, 0.01, "Expect Z to be equal to %f but got %f", 0.1138, xyz->z);
     
     free(xyz);
+    free(rgb);
 }
 
 ctest_return_t testXyzSrgbDark(ctest_t *test, void *arg) {
@@ -51,13 +53,14 @@ ctest_return_t testXyzSrgbDark(ctest_t *test, void *arg) {
     rgb->g = 0;
     rgb->b = 0;
     
-    Xyz * xyz = getXyzFromRgb(rgb, srgb);
+    Xyz *xyz = getXyzFromRgb(rgb, srgb);
     
     CTAssertEqual(test, 0.0, xyz->x, "Expect X to be equal to 0 but got %f", xyz->x);
     CTAssertEqual(test, 0.0, xyz->y, "Expect Y to be equal to 0 but got %f", xyz->y);
     CTAssertEqual(test, 0.0, xyz->z, "Expect Z to be equal to 0 but got %f", xyz->z);
     
     free(xyz);
+    free(rgb);
 }
 
 ctest_return_t testXyzArgbDark(ctest_t *test, void *arg) {
@@ -73,10 +76,11 @@ ctest_return_t testXyzArgbDark(ctest_t *test, void *arg) {
     CTAssertEqual(test, 0.0, xyz->z, "Expect Z to be equal to 0 but got %f", xyz->z);
     
     free(xyz);
+    free(rgb);
 }
 
 ctest_return_t testXyzSRgbBright(ctest_t *test, void *arg) {
-    Rgb * rgb = malloc(sizeof(Rgb));
+    Rgb *rgb = malloc(sizeof(Rgb));
     rgb->r = 255;
     rgb->g = 255;
     rgb->b = 255;
@@ -88,6 +92,7 @@ ctest_return_t testXyzSRgbBright(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, 1.0887, xyz->z, 0.01, "Expect X to be equal to 1.0887 but got %f", xyz->z);
     
     free(xyz);
+    free(rgb);
 }
 
 ctest_return_t testXyzArgbBright(ctest_t *test, void *arg) {
@@ -103,6 +108,7 @@ ctest_return_t testXyzArgbBright(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, 1.0887, xyz->z, 0.01, "Expect X to be equal to 1.0887 but got %f", xyz->z);
     
     free(xyz);
+    free(rgb);
 }
 
 ctest_return_t testXyzRgbNull(ctest_t *test, void *arg) {
@@ -113,35 +119,39 @@ ctest_return_t testXyzRgbNull(ctest_t *test, void *arg) {
 }
 
 ctest_return_t testXyzToRgb(ctest_t *test, void *arg) {
-    Rgb * rgb = malloc(sizeof(Rgb));
+    Rgb *rgb = malloc(sizeof(Rgb));
     rgb->r = 50;
     rgb->g = 10;
     rgb->b = 95;
     
-    Xyz * xyz = getXyzFromRgb(rgb, srgb);
-    Rgb * iamtired = getRgbFromXyz(xyz, srgb);
+    Xyz *xyz = getXyzFromRgb(rgb, srgb);
+    Rgb *iamtired = getRgbFromXyz(xyz, srgb);
     
     CTAssertEqual(test, iamtired->r, 50, "Expect R to be equal to 50 but got %i", iamtired->r);
     CTAssertEqual(test, iamtired->g, 10, "Expect G to be equal to 10 but got %i", iamtired->g);
     CTAssertEqual(test, iamtired->b, 95, "Expect R to be equal to 95 but got %i", iamtired->b);
 
     free(iamtired);
+    free(xyz);
+    free(rgb);
 }
 
 ctest_return_t testXyzToARgb(ctest_t *test, void *arg) {
-    Rgb * rgb = malloc(sizeof(Rgb));
+    Rgb *rgb = malloc(sizeof(Rgb));
     rgb->r = 5;
     rgb->g = 10;
     rgb->b = 98;
     
-    Xyz * xyz = getXyzFromRgb(rgb, adobeRgb);
-    Rgb * iamtired = getRgbFromXyz(xyz, adobeRgb);
+    Xyz *xyz = getXyzFromRgb(rgb, adobeRgb);
+    Rgb *iamtired = getRgbFromXyz(xyz, adobeRgb);
     
     CTAssertEqual(test, iamtired->r, 5, "Expect R to be equal to 50 but got %i", iamtired->r);
     CTAssertEqual(test, iamtired->g, 10, "Expect G to be equal to 10 but got %i", iamtired->g);
     CTAssertEqual(test, iamtired->b, 98, "Expect B to be equal to 95 but got %i", iamtired->b);
     
     free(iamtired);
+    free(rgb);
+    free(xyz);
 }
 
 ctest_return_t testRgbXyzNull(ctest_t *test, void *arg) {

--- a/lymui/tests/ycbcr_test.c
+++ b/lymui/tests/ycbcr_test.c
@@ -49,7 +49,6 @@ ctest_return_t testUintCreationFromYcbcr(ctest_t *test, void *arg) {
     CTAssertEqual(test, 100, rgb->g, "Expect G to be equal to %i but got %i", 100, rgb->g);
     CTAssertEqual(test, 199, rgb->b, "Expect B to be equal to %i but got %i", 198, rgb->b);
     
-    free(ycbcr);
     free(rgb);
 }
 

--- a/lymui/tests/yuv_test.c
+++ b/lymui/tests/yuv_test.c
@@ -26,6 +26,7 @@ ctest_return_t testCaseCreationYuv(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, 0.063, yuv->v, 0.001, "Expect V to be equal to 0.124 but got %f", yuv->v);
 
     free(yuv);
+    free(rgb);
 }
 
 ctest_return_t testWhiteRgbToYuv(ctest_t *test, void *arg) {
@@ -39,6 +40,9 @@ ctest_return_t testWhiteRgbToYuv(ctest_t *test, void *arg) {
     CTAssertDecimalEqual(test, 1.0, yuv->y, 0.1, "Expect Y to be equal to 1.0 but got %f", yuv->y);
     CTAssertDecimalEqual(test, 0.0, yuv->u, 0.1, "Expect U to be equal to 0.0 but got %f", yuv->u);
     CTAssertDecimalEqual(test, 0.0, yuv->v, 0.1, "Expect V to be equal to 0.0 but got %f", yuv->v);
+    
+    free(rgb);
+    free(yuv);
 }
 
 ctest_return_t testCaseCreationNullYuv(ctest_t *test, void *arg) {
@@ -74,6 +78,8 @@ ctest_return_t testWhiteYuvToRgb(ctest_t *test, void *arg) {
     CTAssertEqual(test, 255, rgb->r, "Expect R to be equal to 255 but got %i", rgb->r);
     CTAssertEqual(test, 255, rgb->g, "Expect G to be equal to 255 but got %i", rgb->g);
     CTAssertEqual(test, 255, rgb->b, "Expect B to be equal to 255 but got %i", rgb->b);
+    
+    free(rgb);
 }
 
 ctest_return_t testCreationRgbNULL(ctest_t *test, void *arg) {

--- a/lymui/tsl.c
+++ b/lymui/tsl.c
@@ -77,9 +77,7 @@ Tsl *getTslFromRgb(Rgb *rgb) {
     
     tsl->s = sqrt((9.0 / 5.0) * (powf(rDelta, 2.0) + powf(gDelta, 2.0)));
     tsl->l = 0.299 * _r + 0.587 * _g + 0.114 * _b;
-    
-    free(rgb);
-    
+        
     return tsl;
 }
 

--- a/lymui/xyy.c
+++ b/lymui/xyy.c
@@ -37,8 +37,6 @@ Xyy *getXyyFromXyz(Xyz *xyz) {
     xyy->Y = xyz->y;
     xyy->error = NULL;
     
-    free(xyz);
-    
     return xyy;
 }
 
@@ -52,7 +50,6 @@ Xyz *getXyzFromXyy(Xyy *xyy) {
         xyz->error = NULL_INPUT_STRUCT;
         return xyz;
     }
-    
     
     if (!xyy->y) {
         xyz->x = 0.0;

--- a/lymui/xyz.c
+++ b/lymui/xyz.c
@@ -138,7 +138,6 @@ Xyz *getXyzFromRgb(Rgb *rgb, enum Matrix m) {
     xyz->z = value[2];
     xyz->error = NULL;
     
-    free(rgb);
     free(value);
     
     return xyz;
@@ -149,7 +148,7 @@ Xyz *getXyzFromRgb(Rgb *rgb, enum Matrix m) {
  * @param xyz * Xyz
  * @param m Matrix
  */
-static double * calculateLinearRgbToXyz(Xyz * xyz, Matrix m) {
+static double *calculateLinearRgbToXyz(Xyz * xyz, Matrix m) {
     double *linearRGB = malloc(sizeof(double) * 3);
     if (linearRGB == NULL) {
         return NULL;
@@ -173,9 +172,7 @@ static double * calculateLinearRgbToXyz(Xyz * xyz, Matrix m) {
         linearRGB[1] = unpivotARGB(sg);
         linearRGB[2] = unpivotARGB(sb);
     }
-    
-    
-    free(xyz);
+        
     return linearRGB;
 }
 

--- a/lymui/ycbcr.c
+++ b/lymui/ycbcr.c
@@ -98,6 +98,7 @@ Rgb *getRgbFromYcbcr(Ycbcr *cb) {
     rgb->b = b;
     rgb->error = NULL;
     
-    // don't forget to free when not needed anymore
+    free(cb);
+    
     return rgb;
 }

--- a/lymui/yuv.c
+++ b/lymui/yuv.c
@@ -31,9 +31,7 @@ Yuv *getYuvFromRgb(Rgb *rgb) {
     yuv->u = 0.492 * (_b - _y);
     yuv->v = 0.877 * (_r - _y);
     yuv->error = NULL;
-    
-    free(rgb);
-    
+        
     return yuv;
 }
 


### PR DESCRIPTION
## Lymui

- User might need to use rgb or xyz after manipulating these values with the converters. Therefore it might be better to not freed these values and to let the user do it manually. This pr eliminate freeing the value for any rgb / xyz values.

a uses case can be the one below

```c
Rgb *rgb = malloc(sizeof(Rgb));
rgb->r = 200;
rgb->g = 100;
rgb->b = 0;

// get hsl
Hsl *hsl = getHslFromRgb(rgb);

// get cymk
Cymk *cy = getCymkFromRgb(rgb);

// we don't need rgb anymore so free rgb
free(rgb);
```

### Totoro is going to review your PR

![Totoro](https://cdn.dribbble.com/users/77598/screenshots/3893621/totoro_family.png)

### What does this PR accomplish

- [ ] Add a new feature supporting a new color type
- [ ] Add a new binding supporting for a type color
- [x] Provide a fix to the current project
- [ ] Add new test

### We will check that

- [x] Make sure to have unit test
- [x] Make sure that any test is passing
- [x] Make sure to respect that when converting a ```type T``` to return a ```type T Rgb``` 

🐷 Thanks for contributing ! 🐷

