### PR TITLE
:bug: fix NaN on S value when using a dark rgb

### DIFF
--- a/lymui/tsl.c
+++ b/lymui/tsl.c
@@ -59,6 +59,8 @@ Tsl *getTslFromRgb(Rgb *rgb) {
         tsl->t = 0.0;
         tsl->s = 0.0;
         tsl->l = 0.0;
+        
+        return tsl;
     }
     
     double rNorm  = calculateNorm(_r, _r, _g, _b);


### PR DESCRIPTION
## Lymui

### Totoro is going to review your PR

![Totoro](https://cdn.dribbble.com/users/77598/screenshots/3893621/totoro_family.png)

### What does this PR accomplish

- [ ] Add a new feature supporting a new color type
- [ ] Add a new binding supporting for a type color
- [ ] Provide a fix to the current project
- [ ] Add new test

### We will check that

- [ ] Make sure to have unit test
- [ ] Make sure that any test is passing
- [ ] Make sure to respect that when converting a ```type T``` to return a ```type T Rgb``` 

🐷 Thanks for contributing ! 🐷

